### PR TITLE
Support non-'static readers and writers

### DIFF
--- a/src/fs/sync.rs
+++ b/src/fs/sync.rs
@@ -166,12 +166,12 @@ pub trait RemoteFs {
         &mut self,
         path: &Path,
         metadata: &Metadata,
-        mut reader: Box<dyn Read + Send>,
+        reader: &mut (dyn Read + Send),
     ) -> RemoteResult<u64> {
         if self.is_connected() {
             trace!("Opened remote file");
             let mut stream = self.append(path, metadata)?;
-            let sz = io::copy(&mut reader, &mut stream)
+            let sz = io::copy(reader, &mut stream)
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ProtocolError, e.to_string()))?;
             self.on_written(stream)?;
             trace!("Written {} bytes to destination", sz);
@@ -194,12 +194,12 @@ pub trait RemoteFs {
         &mut self,
         path: &Path,
         metadata: &Metadata,
-        mut reader: Box<dyn Read + Send>,
+        reader: &mut (dyn Read + Send),
     ) -> RemoteResult<u64> {
         if self.is_connected() {
             let mut stream = self.create(path, metadata)?;
             trace!("Opened remote file");
-            let sz = io::copy(&mut reader, &mut stream)
+            let sz = io::copy(reader, &mut stream)
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ProtocolError, e.to_string()))?;
             self.on_written(stream)?;
             trace!("Written {} bytes to destination", sz);
@@ -219,11 +219,11 @@ pub trait RemoteFs {
     /// ### Default implementation
     ///
     /// By default this function uses the streams function to copy content from reader to writer
-    fn open_file(&mut self, src: &Path, mut dest: Box<dyn Write + Send>) -> RemoteResult<u64> {
+    fn open_file(&mut self, src: &Path, dest: &mut (dyn Write + Send)) -> RemoteResult<u64> {
         if self.is_connected() {
             let mut stream = self.open(src)?;
             trace!("File opened");
-            let sz = io::copy(&mut stream, &mut dest)
+            let sz = io::copy(&mut stream, dest)
                 .map_err(|e| RemoteError::new_ex(RemoteErrorType::ProtocolError, e.to_string()))?;
             self.on_read(stream)?;
             trace!("Copied {} bytes to destination", sz);


### PR DESCRIPTION
## Description

I found the status quo of the trait hard to work with in-memory buffers, since the methods requires `'static` readers and writers. Since the operations are blocking, all finishes before they return, it's more natural to support borrowing here.

List here your changes

- I changed the methods to pass mutable borrowed trait objects as readers and writers

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
  * tried to, but existing code already generate warnings (irrelevant with my change)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
